### PR TITLE
링크가 http_prefix를 따르도록 수정 (Fix #20)

### DIFF
--- a/source/partials/_sidebar.haml
+++ b/source/partials/_sidebar.haml
@@ -1,11 +1,11 @@
 #sidebar
   %h2 Would you like to
   %ul
-    %li= link_to '시작하기', '/#getting-started'
+    %li= link_to '시작하기', '/index.html#getting-started'
     %li= link_to '버그 리포트', '/issues.html'
     %li= link_to '새로운 기능 확인하기', "/#{current_version}/whats_new.html"
     %li= link_to '문서 읽기', "/#{current_version}/man/bundle.1.html"
-    %li= link_to '토론하고 기여하기', '/#get-involved'
+    %li= link_to '토론하고 기여하기', '/index.html#get-involved'
     %li= link_to 'FAQ 보기', "/#{current_version}/faq.html"
 
   %h2 최신 뉴스 읽기
@@ -14,7 +14,7 @@
       %li
         = link_to article.title, article.url
     .buttons
-      = link_to '모든 기사', '/blog/'
+      = link_to '모든 기사', '/blog/index.html'
 
   %h2 번들러 명령어
   %ul

--- a/source/sitemap.xml.builder
+++ b/source/sitemap.xml.builder
@@ -1,3 +1,5 @@
+BASE_URL = 'http://ruby-korea.github.io/bundler-site/'
+
 xml.instruct!
 xml.urlset 'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9' do
   xml.url do
@@ -6,9 +8,34 @@ xml.urlset 'xmlns' => 'http://www.sitemaps.org/schemas/sitemap/0.9' do
     xml.changefreq 'weekly'
     xml.priority 1.0
   end
-  sitemap.resources.select{ |resource| resource.ext.eql? '.html' }.each do |resource|
+
+  documents = sitemap.resources.select do |resource|
+    resource.ext.eql? '.html'
+  end
+
+  documents.each do |resource|
     xml.url do
-      xml.loc URI.join('http://ruby-korea.github.io/bundler-site', resource.url)
+      xml.loc URI.join(BASE_URL, resource.url)
+    end
+  end
+
+  versions = 'v1.0'.upto('v1.9')
+  man_files = [
+    'bundle-config.1.html',
+    'bundle-exec.1.html',
+    'bundle-install.1.html',
+    'bundle-package.1.html',
+    'bundle-platform.1.html',
+    'bundle-update.1.html',
+    'bundle.1.html',
+    'gemfile.5.html'
+  ]
+
+  versions.each do |version|
+    man_files.each do |path|
+      xml.url do
+        xml.loc URI.join(BASE_URL, version + '/', 'man/', path)
+      end
     end
   end
 end


### PR DESCRIPTION
#20 문제 해결

middleman의 link_to 함수는 sitemap을 참조합니다. 따라서 index.html을 걸어주면 정상적으로 http_prefix가 적용됩니다.
- http://ruby-korea.github.io/#getting-started
- http://ruby-korea.github.io/#get-involved
- http://ruby-korea.github.io/blog/

아래 url도 마찬가지로 sitemap을 참조하도록 링크해야합니다. 단, man 페이지는 rake 작업으로 동적으로 생성하는 관계로 임시로 man 페이지들을 sitemap에 하드코딩했습니다.
- http://ruby-korea.github.io/v1.9/man/bundle.1.html
